### PR TITLE
Update matlab_calib_2_opencv.m

### DIFF
--- a/matlab/matlab_calib_2_opencv.m
+++ b/matlab/matlab_calib_2_opencv.m
@@ -24,7 +24,7 @@ matlab2opencv(right_parameter,'./../calib_result/cam_right.yml');
 
 %Generate extrinsic parameter yml
 extrinsic_R = stereoParams.RotationOfCamera2;
-extrinsic_T = stereoParams.TranslationOfCamera2* 0.001;
+extrinsic_T = stereoParams.TranslationOfCamera2'* 0.001;
 keySet = {'R','T'};
 valueSet = {extrinsic_R, extrinsic_T};
 extrinsic_parameter = containers.Map(keySet,valueSet);


### PR DESCRIPTION
Transposing Translation Matrix, so the openCV yaml generated will have have 3 rows and 1 column instead of 1 row and 3 columns.
Doesn't affect the file formatting or result generated by cv:stereorectify function in cpp file.